### PR TITLE
Update rules.mk to have rev3 board be the default

### DIFF
--- a/keyboards/keycapsss/plaid_pad/rules.mk
+++ b/keyboards/keycapsss/plaid_pad/rules.mk
@@ -23,4 +23,4 @@ AUDIO_ENABLE = no           # Audio output
 
 LAYOUTS = ortho_4x4
 
-DEFAULT_FOLDER = keycapsss/plaid_pad/rev1
+DEFAULT_FOLDER = keycapsss/plaid_pad/rev3


### PR DESCRIPTION
this is just to improve the usability for those wanting to build for vial and encoder support. I would also suggest adding something basic for the oled screen